### PR TITLE
refactor: Add token issuer

### DIFF
--- a/cmd/issuer-rest/startcmd/start.go
+++ b/cmd/issuer-rest/startcmd/start.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/trustbloc/edge-sandbox/pkg/restapi/issuer"
 	"github.com/trustbloc/edge-sandbox/pkg/restapi/issuer/operation"
+	tokenIssuer "github.com/trustbloc/edge-sandbox/pkg/token/issuer"
 	cmdutils "github.com/trustbloc/edge-sandbox/pkg/utils/cmd"
 )
 
@@ -132,7 +133,7 @@ func startIssuer(parameters *issuerParameters) error {
 		return err
 	}
 
-	cfg := &operation.Config{OAuth2Config: parameters.oauth2Config}
+	cfg := &operation.Config{TokenIssuer: tokenIssuer.New(parameters.oauth2Config)}
 
 	issuerService, err := issuer.New(cfg)
 	if err != nil {

--- a/pkg/restapi/issuer/controller_test.go
+++ b/pkg/restapi/issuer/controller_test.go
@@ -9,21 +9,19 @@ package issuer
 import (
 	"testing"
 
-	"golang.org/x/oauth2"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/trustbloc/edge-sandbox/pkg/restapi/issuer/operation"
 )
 
 func TestController_New(t *testing.T) {
-	controller, err := New(&operation.Config{OAuth2Config: &oauth2.Config{}})
+	controller, err := New(&operation.Config{})
 	require.NoError(t, err)
 	require.NotNil(t, controller)
 }
 
 func TestController_GetOperations(t *testing.T) {
-	controller, err := New(&operation.Config{OAuth2Config: &oauth2.Config{}})
+	controller, err := New(&operation.Config{})
 	require.NoError(t, err)
 	require.NotNil(t, controller)
 

--- a/pkg/restapi/issuer/operation/operations.go
+++ b/pkg/restapi/issuer/operation/operations.go
@@ -7,13 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package operation
 
 import (
-	"context"
-	"crypto/rand"
-	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
@@ -24,13 +20,6 @@ import (
 const (
 	login    = "/login"
 	callback = "/callback"
-
-	oauthCookieName = "oauthstate"
-	stateFormKey    = "state"
-	codeFormKey     = "code"
-
-	defaultCookieExpiry = 20
-	stateValueLength    = 16 // minutes
 )
 
 // Handler http handler for each controller API endpoint
@@ -42,18 +31,23 @@ type Handler interface {
 
 // Operation defines handlers for authorization service
 type Operation struct {
-	handlers  []Handler
-	cmsConfig *oauth2.Config
+	handlers    []Handler
+	tokenIssuer tokenIssuer
 }
 
 // Config defines configuration for issuer operations
 type Config struct {
-	OAuth2Config *oauth2.Config
+	TokenIssuer tokenIssuer
+}
+
+type tokenIssuer interface {
+	AuthCodeURL(w http.ResponseWriter) string
+	Exchange(r *http.Request) (*oauth2.Token, error)
 }
 
 // New returns authorization instance
 func New(config *Config) *Operation {
-	svc := &Operation{cmsConfig: config.OAuth2Config}
+	svc := &Operation{tokenIssuer: config.TokenIssuer}
 	svc.registerHandler()
 
 	return svc
@@ -61,17 +55,13 @@ func New(config *Config) *Operation {
 
 // Login using oauth2, will redirect to Auth Code URL
 func (c *Operation) Login(w http.ResponseWriter, r *http.Request) {
-	// AuthCodeURL receives state that is a token to protect the user from CSRF attacks
-	oauthState := generateStateOauthCookie(w)
-
-	u := c.cmsConfig.AuthCodeURL(oauthState)
+	u := c.tokenIssuer.AuthCodeURL(w)
 	http.Redirect(w, r, u, http.StatusTemporaryRedirect)
 }
 
 // Callback for oauth2 login
 func (c *Operation) Callback(w http.ResponseWriter, r *http.Request) {
-	// read oauthState from cookie
-	oauthState, err := r.Cookie(oauthCookieName)
+	_, err := c.tokenIssuer.Exchange(r)
 	if err != nil {
 		log.Error(err)
 		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
@@ -79,44 +69,8 @@ func (c *Operation) Callback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// validate that oauth cookie state matches the the state query parameter on your redirect callback
-	if r.FormValue(stateFormKey) != oauthState.Value {
-		log.Warn("invalid oauth state")
-		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
-
-		return
-	}
-
-	// exchange code for token
-	_, err = c.cmsConfig.Exchange(context.Background(), r.FormValue(codeFormKey))
-	if err != nil {
-		log.Error(err)
-		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
-
-		return
-	}
-
-	// get user data from CMS here (display token for now)
+	// get user data from CMS here (hard-code vc for now)
 	c.writeResponse(w, validCredential)
-}
-
-func generateStateOauthCookie(w http.ResponseWriter) string {
-	// generate random bytes for state value
-	b := make([]byte, stateValueLength)
-
-	_, err := rand.Read(b)
-	if err != nil {
-		log.Error(err)
-	}
-
-	state := base64.URLEncoding.EncodeToString(b)
-	cookie := http.Cookie{Name: oauthCookieName,
-		Value:   state,
-		Expires: time.Now().Add(defaultCookieExpiry * time.Minute)}
-
-	http.SetCookie(w, &cookie)
-
-	return state
 }
 
 // registerHandler register handlers to be exposed from this service as REST API endpoints

--- a/pkg/token/issuer/issuer.go
+++ b/pkg/token/issuer/issuer.go
@@ -1,0 +1,87 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package issuer
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/oauth2"
+)
+
+const (
+	oauthCookieName = "oauthstate"
+	stateFormKey    = "state"
+	codeFormKey     = "code"
+
+	defaultCookieExpiry = 20
+	stateValueLength    = 16 // minutes
+)
+
+// Issuer implements token issuing
+type Issuer struct {
+	oauthConfig *oauth2.Config
+}
+
+// New creates new token issuer
+func New(oauthConfig *oauth2.Config) *Issuer {
+	return &Issuer{oauthConfig: oauthConfig}
+}
+
+// AuthCodeURL returns a URL to OAuth 2.0 provider's consent page
+func (i *Issuer) AuthCodeURL(w http.ResponseWriter) string {
+	// AuthCodeURL receives state that is a token to protect the user from CSRF attacks
+	oauthState := generateStateOauthCookie(w)
+
+	return i.oauthConfig.AuthCodeURL(oauthState)
+}
+
+// Exchange will exchange auth code for auth token
+func (i *Issuer) Exchange(r *http.Request) (*oauth2.Token, error) {
+	// read oauthState from cookie
+	oauthState, err := r.Cookie(oauthCookieName)
+	if err != nil {
+		return nil, err
+	}
+
+	// validate that oauth cookie state matches the the state query parameter on your redirect callback
+	if r.FormValue(stateFormKey) != oauthState.Value {
+		return nil, errors.New("invalid oauth state")
+	}
+
+	// exchange code for token
+	token, err := i.oauthConfig.Exchange(context.Background(), r.FormValue(codeFormKey))
+	if err != nil {
+		return nil, err
+	}
+
+	return token, nil
+}
+
+func generateStateOauthCookie(w http.ResponseWriter) string {
+	// generate random bytes for state value
+	b := make([]byte, stateValueLength)
+
+	_, err := rand.Read(b)
+	if err != nil {
+		log.Error(err)
+	}
+
+	state := base64.URLEncoding.EncodeToString(b)
+	cookie := http.Cookie{Name: oauthCookieName,
+		Value:   state,
+		Expires: time.Now().Add(defaultCookieExpiry * time.Minute)}
+
+	http.SetCookie(w, &cookie)
+
+	return state
+}

--- a/pkg/token/issuer/issuer_test.go
+++ b/pkg/token/issuer/issuer_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package issuer
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+func TestIssuer_AuthCodeURL(t *testing.T) {
+	tokenIssuer := New(&oauth2.Config{})
+
+	w := httptest.NewRecorder()
+	u := tokenIssuer.AuthCodeURL(w)
+	require.NotEmpty(t, u)
+}
+
+func TestIssuer_Exchange_NoStateCookie(t *testing.T) {
+	req, err := getRequest(nil, nil)
+	require.NoError(t, err)
+
+	tokenIssuer := New(&oauth2.Config{})
+
+	token, err := tokenIssuer.Exchange(req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "http: named cookie not present")
+	require.Nil(t, token)
+}
+
+func TestIssuer_Exchange_NoStateValue(t *testing.T) {
+	oauthCookie := &http.Cookie{
+		Name:  oauthCookieName,
+		Value: "value",
+	}
+
+	req, err := getRequest([]*http.Cookie{oauthCookie}, nil)
+	require.NoError(t, err)
+
+	tokenIssuer := New(&oauth2.Config{})
+
+	token, err := tokenIssuer.Exchange(req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid oauth state")
+	require.Nil(t, token)
+}
+
+func TestIssuer_Exchange_GetTokenError(t *testing.T) {
+	const oauthCookieValue = "some value"
+
+	cookie := &http.Cookie{
+		Name:  oauthCookieName,
+		Value: oauthCookieValue,
+	}
+	cookies := []*http.Cookie{cookie}
+
+	formValues := make(map[string][]string)
+	formValues["state"] = []string{oauthCookieValue}
+
+	req, err := getRequest(cookies, formValues)
+	require.NoError(t, err)
+
+	tokenIssuer := New(&oauth2.Config{})
+
+	token, err := tokenIssuer.Exchange(req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Post : unsupported protocol scheme")
+	require.Nil(t, token)
+}
+
+func getRequest(cookies []*http.Cookie, formValues map[string][]string) (*http.Request, error) {
+	req, err := http.NewRequest("method", "path", bytes.NewBuffer([]byte("")))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, c := range cookies {
+		req.AddCookie(c)
+	}
+
+	req.Form = formValues
+
+	return req, nil
+}


### PR DESCRIPTION
Move code for issuing token into separate component e.g. token issuer. It will simplify operation handler code and make implementing handler unit-tests easier.

Closes #15

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>