### PR TITLE
feat: Add Token Resolver

### DIFF
--- a/cmd/issuer-rest/startcmd/start_test.go
+++ b/cmd/issuer-rest/startcmd/start_test.go
@@ -148,8 +148,17 @@ func TestStartIssuerWithBlankHost(t *testing.T) {
 	require.Contains(t, err.Error(), "host URL is empty")
 }
 
+func TestStartIssuerWithBlankTokentIntrospectionURL(t *testing.T) {
+	parameters := &issuerParameters{hostURL: "hostURL", tokenIntrospectionURL: ""}
+
+	err := startIssuer(parameters)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "token introspection URL is empty")
+}
+
 func TestStartIssuerWithInvalidOAuth2Config(t *testing.T) {
-	parameters := &issuerParameters{hostURL: "hostURL", oauth2Config: &oauth2.Config{Endpoint: oauth2.Endpoint{}}}
+	parameters := &issuerParameters{hostURL: "hostURL", tokenIntrospectionURL: "introspect",
+		oauth2Config: &oauth2.Config{Endpoint: oauth2.Endpoint{}}}
 
 	err := startIssuer(parameters)
 	require.NotNil(t, err)
@@ -188,6 +197,9 @@ func TestStartCmdValidArgsEnvVar(t *testing.T) {
 	require.Nil(t, err)
 
 	err = os.Setenv(clientScopesEnvKey, "scopes")
+	require.Nil(t, err)
+
+	err = os.Setenv(introspectionURLEnvKey, "endpoint/introspect")
 	require.Nil(t, err)
 
 	err = startCmd.Execute()
@@ -253,6 +265,7 @@ func getValidArgs() []string {
 	args = append(args, clientIDArg()...)
 	args = append(args, clientSecretArg()...)
 	args = append(args, clientScopesArg()...)
+	args = append(args, tokenIntrospectionURLArg()...)
 
 	return args
 }
@@ -283,4 +296,8 @@ func clientSecretArg() []string {
 
 func clientScopesArg() []string {
 	return []string{flag + clientScopesFlagName, "openid"}
+}
+
+func tokenIntrospectionURLArg() []string {
+	return []string{flag + introspectionURLFlagName, "endpoint/introspect"}
 }

--- a/pkg/token/introspection.go
+++ b/pkg/token/introspection.go
@@ -1,0 +1,71 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package token
+
+// Introspection contains an access token's session data as specified by IETF RFC 7662
+// https://tools.ietf.org/html/rfc7662
+type Introspection struct {
+	// Active is a boolean indicator of whether or not the presented token
+	// is currently active.  The specifics of a token's "active" state
+	// will vary depending on the implementation of the authorization
+	// server and the information it keeps about its tokens, but a "true"
+	// value return for the "active" property will generally indicate
+	// that a given token has been issued by this authorization server,
+	// has not been revoked by the resource owner, and is within its
+	// given time window of validity (e.g., after its issuance time and
+	// before its expiration time).
+	//
+	// required: true
+	Active bool `json:"active"`
+
+	// Scope is a JSON string containing a space-separated list of
+	// scopes associated with this token.
+	Scope string `json:"scope,omitempty"`
+
+	// ClientID is aclient identifier for the OAuth 2.0 client that
+	// requested this token.
+	ClientID string `json:"client_id,omitempty"`
+
+	// Username is a human-readable identifier for the resource owner who
+	// authorized this token.
+	Username string `json:"username,omitempty"`
+
+	// TokenType is the introspected token's type, for example `access_token` or `refresh_token`.
+	TokenType string `json:"token_type,omitempty"`
+
+	// Expires at is an integer timestamp, measured in the number of seconds
+	// since January 1 1970 UTC, indicating when this token will expire.
+	ExpiresAt int64 `json:"exp,omitempty"`
+
+	// Issued at is an integer timestamp, measured in the number of seconds
+	// since January 1 1970 UTC, indicating when this token was
+	// originally issued.
+	IssuedAt int64 `json:"iat,omitempty"`
+
+	// NotBefore is an integer timestamp, measured in the number of seconds
+	// since January 1 1970 UTC, indicating when this token is not to be
+	// used before.
+	NotBefore int64 `json:"nbf,omitempty"`
+
+	// Subject of the token, as defined in JWT [RFC7519].
+	// Usually a machine-readable identifier of the resource owner who
+	// authorized this token.
+	Subject string `json:"sub,omitempty"`
+
+	// ObfuscatedSubject is set when the subject identifier algorithm was set to "pairwise" during authorization.
+	// It is the `sub` value of the ID Token that was issued.
+	ObfuscatedSubject string `json:"obfuscated_subject,omitempty"`
+
+	// Audience contains a list of the token's intended audiences.
+	Audience []string `json:"aud,omitempty"`
+
+	// IssuerURL is a string representing the issuer of this token
+	Issuer string `json:"iss,omitempty"`
+
+	// Extra is arbitrary data set by the session.
+	Extra map[string]interface{} `json:"ext,omitempty"`
+}

--- a/pkg/token/resolver/resolver.go
+++ b/pkg/token/resolver/resolver.go
@@ -1,0 +1,69 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resolver
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/trustbloc/edge-sandbox/pkg/token"
+)
+
+const tokenFormKey = "token"
+
+// Resolver implements token resolution
+type Resolver struct {
+	tokenIntrospectionURL string
+}
+
+// New creates new token resolver
+func New(tokenIntrospectionURL string) *Resolver {
+	return &Resolver{tokenIntrospectionURL: tokenIntrospectionURL}
+}
+
+// Resolve returns token information based on token
+func (r *Resolver) Resolve(tk string) (*token.Introspection, error) {
+	resp, err := http.PostForm(r.tokenIntrospectionURL,
+		url.Values{tokenFormKey: {tk}})
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		err := resp.Body.Close()
+		if err != nil {
+			log.Warn("failed to close response body")
+		}
+	}()
+
+	return getTokenInfo(resp)
+}
+
+func getTokenInfo(resp *http.Response) (*token.Introspection, error) {
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New("http status code is not ok")
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	info := &token.Introspection{}
+
+	err = json.Unmarshal(body, info)
+	if err != nil {
+		return nil, err
+	}
+
+	return info, nil
+}

--- a/pkg/token/resolver/resolver_test.go
+++ b/pkg/token/resolver/resolver_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resolver
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolver_Resolve(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, jsonBody)
+	}))
+	defer ts.Close()
+
+	tokenIssuer := New(ts.URL)
+
+	tk, err := tokenIssuer.Resolve("token")
+	require.NoError(t, err)
+	require.NotNil(t, tk)
+	require.Equal(t, true, tk.Active)
+	require.Equal(t, "a@b.com", tk.Subject)
+}
+
+func TestResolver_Resolve_Error(t *testing.T) {
+	tokenIssuer := New("http://localhost/introspect")
+
+	tk, err := tokenIssuer.Resolve("token")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "connection refused")
+	require.Empty(t, tk)
+}
+
+func TestResolver_GetTokenInfo(t *testing.T) {
+	w := httptest.NewRecorder()
+	_, err := w.WriteString(jsonBody)
+	require.NoError(t, err)
+
+	resp := w.Result()
+
+	tk, err := getTokenInfo(resp)
+	require.NoError(t, err)
+	require.NotNil(t, tk)
+	require.Equal(t, true, tk.Active)
+	require.Equal(t, "a@b.com", tk.Subject)
+
+	err = resp.Body.Close()
+	require.NoError(t, err)
+}
+
+func TestResolver_GetTokenInfo_StatusNotOK(t *testing.T) {
+	tk, err := getTokenInfo(&http.Response{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "http status code is not ok")
+	require.Nil(t, tk)
+}
+
+func TestResolver_GetTokenInfo_ReadBodyError(t *testing.T) {
+	w := httptest.NewRecorder()
+	resp := w.Result()
+
+	resp.Body = &mockReader{}
+
+	tk, err := getTokenInfo(resp)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "reader error")
+	require.Nil(t, tk)
+
+	err = resp.Body.Close()
+	require.NoError(t, err)
+}
+
+func TestResolver_GetTokenInfo_JSONUnmarshalError(t *testing.T) {
+	w := httptest.NewRecorder()
+	resp := w.Result()
+
+	tk, err := getTokenInfo(resp)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected end of JSON input")
+	require.Nil(t, tk)
+
+	err = resp.Body.Close()
+	require.NoError(t, err)
+}
+
+type mockReader struct{}
+
+func (r *mockReader) Read(p []byte) (n int, err error) {
+	return 0, errors.New("reader error")
+}
+
+func (r *mockReader) Close() error {
+	return nil
+}
+
+const jsonBody = `{
+  "active": true,
+  "sub": "a@b.com"
+}
+`


### PR DESCRIPTION
Token resolver will issue a call to introspection endpoint and return token/introspection info.

Closes #11

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>