### PR TITLE
feat: Integrate Hydra Oathkeeper and CMS into flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ coverage.txt
 build
 
 test/bdd/fixtures/keys/tls
+
+

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ license:
 unit-test:
 	@scripts/check_unit.sh
 
+
 sandbox-start: clean issuer-rest-docker generate-test-keys
 	@scripts/sandbox_start.sh
 

--- a/cmd/issuer-rest/startcmd/start_test.go
+++ b/cmd/issuer-rest/startcmd/start_test.go
@@ -179,6 +179,9 @@ func TestStartCmdValidArgsEnvVar(t *testing.T) {
 	err = os.Setenv(tlsCertFileEnvKey, "cert")
 	require.Nil(t, err)
 
+	err = os.Setenv(cmsURLEnvKey, "cms")
+	require.Nil(t, err)
+
 	err = os.Setenv(tlsKeyFileEnvKey, "key")
 	require.Nil(t, err)
 
@@ -211,6 +214,7 @@ func getValidArgs() []string {
 	args = append(args, tokenIntrospectionURLArg()...)
 	args = append(args, tlsCertFileArg()...)
 	args = append(args, tlsKeyFileArg()...)
+	args = append(args, cmsURLArg()...)
 
 	return args
 }
@@ -253,4 +257,8 @@ func tlsCertFileArg() []string {
 
 func tlsKeyFileArg() []string {
 	return []string{flag + tlsKeyFileFlagName, "key"}
+}
+
+func cmsURLArg() []string {
+	return []string{flag + cmsURLFlagName, "cms"}
 }

--- a/cmd/strapi-demo/createdemodata/start_test.go
+++ b/cmd/strapi-demo/createdemodata/start_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -78,6 +79,9 @@ func TestAdminUserAndCreateRecordWithRoundTripper(t *testing.T) {
 		require.NotNil(t, token)
 		require.Nil(t, err)
 		require.Equal(t, "Bearer eyJhbGciOiJIU", token)
+
+		err = os.Remove(strapiCodeFile)
+		require.NoError(t, err)
 	})
 	t.Run("add the student record and verify", func(t *testing.T) {
 		client2 := NewTestClient(func(req *http.Request) *http.Response {
@@ -94,6 +98,9 @@ func TestAdminUserAndCreateRecordWithRoundTripper(t *testing.T) {
 		parameters := &strapiDemoParameters{client: client2, adminURL: testURL}
 		err := startStrapiDemo(parameters)
 		require.Nil(t, err)
+
+		err = os.Remove(strapiCodeFile)
+		require.NoError(t, err)
 	})
 	t.Run("error while verifying record", func(t *testing.T) {
 		client2 := NewTestClient(func(req *http.Request) *http.Response {
@@ -110,6 +117,9 @@ func TestAdminUserAndCreateRecordWithRoundTripper(t *testing.T) {
 		err := startStrapiDemo(parameters)
 		require.NotNil(t, err)
 		require.Contains(t, err.Error(), "fetched record doesnt match the stored record")
+
+		err = os.Remove(strapiCodeFile)
+		require.NoError(t, err)
 	})
 	t.Run("error while getting record ", func(t *testing.T) {
 		client := NewTestClient(func(req *http.Request) *http.Response {

--- a/pkg/token/issuer/issuer.go
+++ b/pkg/token/issuer/issuer.go
@@ -67,6 +67,11 @@ func (i *Issuer) Exchange(r *http.Request) (*oauth2.Token, error) {
 	return token, nil
 }
 
+// Client returns an HTTP client using the provided token.
+func (i *Issuer) Client(ctx context.Context, t *oauth2.Token) *http.Client {
+	return oauth2.NewClient(ctx, i.oauthConfig.TokenSource(ctx, t))
+}
+
 func generateStateOauthCookie(w http.ResponseWriter) string {
 	// generate random bytes for state value
 	b := make([]byte, stateValueLength)

--- a/pkg/token/issuer/issuer_test.go
+++ b/pkg/token/issuer/issuer_test.go
@@ -8,6 +8,7 @@ package issuer
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -22,6 +23,13 @@ func TestIssuer_AuthCodeURL(t *testing.T) {
 	w := httptest.NewRecorder()
 	u := tokenIssuer.AuthCodeURL(w)
 	require.NotEmpty(t, u)
+}
+
+func TestIssuer_Client(t *testing.T) {
+	tokenIssuer := New(&oauth2.Config{})
+
+	c := tokenIssuer.Client(context.Background(), &oauth2.Token{})
+	require.NotNil(t, c)
 }
 
 func TestIssuer_Exchange_NoStateCookie(t *testing.T) {

--- a/scripts/strapi-setup.sh
+++ b/scripts/strapi-setup.sh
@@ -31,7 +31,7 @@ echo "Generating Strapi API"
 echo "Inside app folder to install APIs"
 
 # generate the student cards api and model
-GENERATE_STUDENTAPI_COMMAND="npx strapi generate:api studentcards StudentID:string Name:string University:string Semester:string"
+GENERATE_STUDENTAPI_COMMAND="npx strapi generate:api studentcards StudentID:string Name:string Email:string University:string Semester:string"
 
 $GENERATE_STUDENTAPI_COMMAND
 
@@ -45,3 +45,6 @@ sleep 20s
 # This is assuming strapi is running on default 1337 port
 cd ../../../../../build/bin
 ./strapi-demo create-demo-data --host-url http://localhost:1337
+
+sed -e "s/{TOKEN}/$(sed 's:/:\\/:g' ./strapi.txt)/" ../../test/bdd/fixtures/oathkeeper/rules/resource-server-template.json > ../../test/bdd/fixtures/oathkeeper/rules/resource-server.json
+

--- a/test/bdd/fixtures/oathkeeper/config.yaml
+++ b/test/bdd/fixtures/oathkeeper/config.yaml
@@ -1,0 +1,45 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+serve:
+  proxy:
+    port: 4455 # run the proxy at port 4455
+  api:
+    port: 4456 # run the api at port 4456
+
+access_rules:
+  repositories:
+    - file:///oathkeeper/rules/resource-server.json
+
+# Global configuration file oathkeeper.yml
+authenticators:
+  oauth2_introspection:
+    # Set enabled to true if the authenticator should be enabled and false to disable the authenticator. Defaults to false.
+    enabled: true
+
+    config:
+      introspection_url: http://hydra:4445/oauth2/introspect
+      scope_strategy: exact
+      required_scope:
+        - studentcard
+
+authorizers:
+  allow:
+    # Set enabled to true if the authenticator should be enabled and false to disable the authenticator. Defaults to false.
+    enabled: true
+
+mutators:
+  header:
+    enabled: true
+    config:
+      headers:
+        X-User: "{{ print .Subject }}"
+        Authentication: "Bearer ABC"
+        # You could add some other headers, for example with data from the
+        # session.
+        # X-Some-Arbitrary-Data: "{{ print .Extra.some.arbitrary.data }}"
+  noop:
+    enabled: true

--- a/test/bdd/fixtures/oathkeeper/rules/resource-server-template.json
+++ b/test/bdd/fixtures/oathkeeper/rules/resource-server-template.json
@@ -1,0 +1,38 @@
+[
+{
+  "id": "resource-server-rule",
+  "upstream": {
+    "url": "http://strapi:1337"
+  },
+  "match": {
+    "url": "http://oathkeeper-proxy:4455/<.*>",
+    "methods": [
+      "GET"
+    ]
+  },
+  "authenticators": [
+    {
+      "handler": "oauth2_introspection",
+      "config": {
+        "required_scope": [
+          "studentcard"
+        ]
+      }
+    }
+  ],
+  "mutators": [
+    {
+      "handler": "header",
+      "config": {
+        "headers": {
+          "X-User": "{{ print .Subject }}",
+          "Authorization": "Bearer {TOKEN}"
+        }
+      }
+    }
+  ],
+  "authorizer": {
+    "handler": "allow"
+  }
+}
+]

--- a/test/bdd/fixtures/oathkeeper/rules/resource-server.json
+++ b/test/bdd/fixtures/oathkeeper/rules/resource-server.json
@@ -1,0 +1,38 @@
+[
+{
+  "id": "resource-server-rule",
+  "upstream": {
+    "url": "http://strapi:1337"
+  },
+  "match": {
+    "url": "http://oathkeeper-proxy:4455/<.*>",
+    "methods": [
+      "GET"
+    ]
+  },
+  "authenticators": [
+    {
+      "handler": "oauth2_introspection",
+      "config": {
+        "required_scope": [
+          "studentcard"
+        ]
+      }
+    }
+  ],
+  "mutators": [
+    {
+      "handler": "header",
+      "config": {
+        "headers": {
+          "X-User": "{{ print .Subject }}",
+          "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaXNBZG1pbiI6dHJ1ZSwiaWF0IjoxNTc5MjkwMjM5LCJleHAiOjE1ODE4ODIyMzl9.JNFUaLl35B3FCPwlos2mEPVnmJTfnJ9mjJWEQ6bcb7c"
+        }
+      }
+    }
+  ],
+  "authorizer": {
+    "handler": "allow"
+  }
+}
+]

--- a/test/bdd/fixtures/sandbox/docker-compose.yml
+++ b/test/bdd/fixtures/sandbox/docker-compose.yml
@@ -40,6 +40,22 @@ services:
       - "3000:3000"
     restart: unless-stopped
 
+  oathkeeper-proxy:
+    image: oryd/oathkeeper:latest
+    ports:
+      - "4455:4455"
+    depends_on:
+      - hydra
+    command:
+      serve proxy --config /oathkeeper/config.yaml
+    environment:
+      - LOG_LEVEL=debug
+      - PORT=4455
+      - ISSUER_URL=http://localhost:4455/
+    restart: on-failure
+    volumes:
+      - ../oathkeeper:/oathkeeper
+
   mysqld:
     image: mysql:5.7
     ports:
@@ -91,6 +107,7 @@ services:
       - OAUTH2_ENDPOINT_TOKEN_INTROSPECTION_URL=http://hydra:4445/oauth2/introspect
       - ISSUER_TLS_CERT_FILE=/etc/tls/ec-pubCert.pem
       - ISSUER_TLS_KEY_FILE=/etc/tls/ec-key.pem
+      - ISSUER_CMS_URL=http://oathkeeper-proxy:4455
     ports:
       - 5556:5556
     command: start


### PR DESCRIPTION
Integrate Hydra Oathkeeper in reverse proxy mode. The port exposing the reverse proxy forwards requests to the upstream server, defined in the rule, if the request is allowed. If the request is not allowed, ORY Oathkeeper does not forward the request and instead returns an error message.

This reverse proxy will be used to access CMS data.

Closes #10

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>