### PR TITLE
chore: Update to latest sidetree + edge service

### DIFF
--- a/test/bdd/fixtures/demo/.env
+++ b/test/bdd/fixtures/demo/.env
@@ -9,7 +9,7 @@ ARCH=amd64
 ISSUER_IMAGE=docker.pkg.github.com/trustbloc/edge-sandbox/issuer-rest
 RP_IMAGE=docker.pkg.github.com/trustbloc/edge-sandbox/rp-rest
 VCS_IMAGE=docker.pkg.github.com/trustbloc/edge-service/vc-rest
-VCS_IMAGE_TAG=0.1.2-snapshot-ec6ecf7
+VCS_IMAGE_TAG=0.1.2-snapshot-b535ba2
 EDV_IMAGE=docker.pkg.github.com/trustbloc/edv/edv-rest
 EDV_IMAGE_TAG=0.1.2-snapshot-75d5b1e
 USER_AGENT_WASM_IMAGE=docker.pkg.github.com/trustbloc/edge-agent/user-agent-wasm
@@ -32,9 +32,7 @@ WS_SCHEME=ws
 
 # Sidetree mock
 SIDETREE_MOCK_IMAGE=docker.pkg.github.com/trustbloc/sidetree-mock/sidetree
-SIDETREE_MOCK_IMAGE_TAG=amd64-0.1.2-snapshot-79fb4b3
-
-
+SIDETREE_MOCK_IMAGE_TAG=amd64-0.1.2-snapshot-9754ba5
 
 # baseos
 FABRIC_BASEOS_FIXTURE_IMAGE=hyperledger/fabric-baseos
@@ -50,7 +48,7 @@ FABRIC_ORDERER_FIXTURE_TAG=2.0.0
 
 # fabric peer
 FABRIC_PEER_FIXTURE_IMAGE=docker.pkg.github.com/trustbloc/sidetree-fabric/peer
-FABRIC_PEER_FIXTURE_TAG=0.1.2-snapshot-2688a3f
+FABRIC_PEER_FIXTURE_TAG=0.1.2-snapshot-b6e0a81
 
 
 # fabric cc env


### PR DESCRIPTION
Update to latest sidetree (mock and fabric) and edge service. 

Also, run with sidetree fabric by executing  "make demo-start-with-sidetree-fabric"

Closes #111

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>