### PR TITLE
chore: User Agent Update to use image with Generic wasm

### DIFF
--- a/test/bdd/fixtures/demo/.env
+++ b/test/bdd/fixtures/demo/.env
@@ -13,7 +13,7 @@ VCS_IMAGE_TAG=0.1.3-snapshot-b189033
 EDV_IMAGE=docker.pkg.github.com/trustbloc/edv/edv-rest
 EDV_IMAGE_TAG=0.1.2
 USER_AGENT_WASM_IMAGE=docker.pkg.github.com/trustbloc/edge-agent/user-agent-wasm
-USER_AGENT_WASM_IMAGE_TAG=amd64-0.1.3-snapshot-54b86c7
+USER_AGENT_WASM_IMAGE_TAG=amd64-0.1.3-snapshot-054adb2
 
 # Aries Agent configurations
 ARIES_AGENT_REST_IMAGE=docker.pkg.github.com/hyperledger/aries-framework-go/agent-rest


### PR DESCRIPTION
closes #138 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>