### PR TITLE
feat: Map token subject to CMS user

### DIFF
--- a/docs/demo/build.md
+++ b/docs/demo/build.md
@@ -66,6 +66,6 @@ Open [user agent register wallet](https://127.0.0.1:8091/RegisterWallet) and fol
 
 ## Demo
 
-To create student card verifiable credential open [issuer home page](https://127.0.0.1:5556/) and follow the links.
+To create student card verifiable credential open [issuer home page](https://127.0.0.1:5556/) and follow the links. You can login as our pre-defined user foo@bar.com or set-up your own user using Strapi admin application.
 
 After creating student card verifiable credential open [rp home page](https://127.0.0.1:5557/) and follow the links.

--- a/test/bdd/fixtures/oathkeeper/rules/resource-server-template.json
+++ b/test/bdd/fixtures/oathkeeper/rules/resource-server-template.json
@@ -1,11 +1,46 @@
 [
   {
-    "id": "resource-server-rule",
+    "id": "users-resource-server-rule",
     "upstream": {
       "url": "http://strapi:1337"
     },
     "match": {
-      "url": "http://oathkeeper-proxy:4455/studentcards/<.*>",
+      "url": "http://oathkeeper-proxy:4455/users<.*>",
+      "methods": [
+        "GET"
+      ]
+    },
+    "authenticators": [
+      {
+        "handler": "oauth2_introspection",
+        "config": {
+          "required_scope": [
+          ]
+        }
+      }
+    ],
+    "mutators": [
+      {
+        "handler": "header",
+        "config": {
+          "headers": {
+            "X-User": "{{ print .Subject }}",
+            "Authorization": "Bearer {TOKEN}"
+          }
+        }
+      }
+    ],
+    "authorizer": {
+      "handler": "allow"
+    }
+  },
+  {
+    "id": "studentcards-resource-server-rule",
+    "upstream": {
+      "url": "http://strapi:1337"
+    },
+    "match": {
+      "url": "http://oathkeeper-proxy:4455/studentcards<.*>",
       "methods": [
         "GET"
       ]
@@ -36,12 +71,12 @@
     }
   },
   {
-    "id": "travelcard-resource-server-rule",
+    "id": "travelcards-resource-server-rule",
     "upstream": {
       "url": "http://strapi:1337"
     },
     "match": {
-      "url": "http://oathkeeper-proxy:4455/travelcards/<.*>",
+      "url": "http://oathkeeper-proxy:4455/travelcards<.*>",
       "methods": [
         "GET"
       ]


### PR DESCRIPTION
Change includes:
- add cms user table to Strapi and configure initial user foo@bar.com
- issuer will retrieve CMS user by email that is provided in token subject
- issuer will retrieve student card and travel card info based on retrieved CMS user ID

Closes #160

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>