### PR TITLE
fix: unsupported protocol scheme test on linux

### DIFF
--- a/pkg/token/issuer/issuer_test.go
+++ b/pkg/token/issuer/issuer_test.go
@@ -85,7 +85,7 @@ func TestIssuer_Exchange_GetTokenError(t *testing.T) {
 
 	token, err := tokenIssuer.Exchange(req)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Post : unsupported protocol scheme")
+	require.Contains(t, err.Error(), "unsupported protocol scheme")
 	require.Nil(t, token)
 }
 


### PR DESCRIPTION
in my laptop the error message is slightly different than what is expected and therefore this test fails:

```
  Post "": unsupported protocol scheme ""
```

I'm on Ubuntu 18.04.

Signed-off-by: George Aristy <george.aristy@securekey.com>