### PR TITLE
feat: #397 install rp adapter components

### DIFF
--- a/images/rp-rest/Dockerfile
+++ b/images/rp-rest/Dockerfile
@@ -24,6 +24,10 @@ RUN make rp-rest
 
 
 FROM alpine:${ALPINE_VER}
+RUN apk add --no-cache \
+    bash \
+    curl \
+    jq;
 
 # copy build artifacts from build container
 COPY --from=edge-sandbox /opt/workspace/edge-sandbox/.build/bin/rp /usr/local/bin

--- a/scripts/sandbox_stop.sh
+++ b/scripts/sandbox_stop.sh
@@ -7,6 +7,13 @@
 
 echo "Running $0"
 
-cd test/bdd/fixtures/demo
-docker-compose kill
-docker-compose rm -f
+sidetreeCompseFile='-f docker-compose-sidetree-mock.yml'
+if [ "$START_SIDETREE_FABRIC" = true ] ; then
+    sidetreeCompseFile='-f docker-compose-sidetree-fabric.yml'
+fi
+
+dockerComposeFiles="-f docker-compose-third-party.yml -f docker-compose-didcomm.yml -f docker-compose-edge-components.yml -f docker-compose-demo-applications.yml -f docker-compose-universal-resolver.yml -f docker-compose-universal-registrar.yml $sidetreeCompseFile"
+(cd test/bdd/fixtures/demo && docker-compose $dockerComposeFiles down)
+
+echo ""
+echo "Sandbox stopped!"

--- a/scripts/trustbloc_local_setup.sh
+++ b/scripts/trustbloc_local_setup.sh
@@ -34,4 +34,6 @@ cat > ${SANDBOX_HOME}/hosts <<EOF
 127.0.0.1 org3.trustbloc.local
 127.0.0.1 testnet.trustbloc.local
 127.0.0.1 issuer-adapter.trustbloc.local
+127.0.0.1 rp-adapter.trustbloc.local
+127.0.0.1 rp-adapter-hydra.trustbloc.local
 EOF

--- a/test/bdd/fixtures/demo/.env
+++ b/test/bdd/fixtures/demo/.env
@@ -75,6 +75,8 @@ ARIES_AGENT_REST_IMAGE_TAG=amd64-0.1.4-snapshot-b180f85
 # Edge adapter
 ISSUER_ADAPTER_REST_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/issuer-adapter-rest
 ISSUER_ADAPTER_REST_IMAGE_TAG=0.1.4-snapshot-78e74f3
+RP_ADAPTER_REST_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/rp-adapter-rest
+RP_ADAPTER_REST_IMAGE_TAG=0.1.4-snapshot-17dfed6
 
 # Transport Schemes
 HTTP_SCHEME=http
@@ -87,7 +89,19 @@ DIDCOMM_ROUTER_WS_INBOUND_PORT=9082
 DIDCOMM_ROUTER_API_PORT=9084
 DIDCOMM_ROUTER_DB_PATH=/tmp/db/aries
 
-# Issuer agent configuration
+# Issuer Adapter agent configuration
 ISSUER_ADAPTER_HOST=0.0.0.0
 ISSUER_ADAPTER_PORT=10061
 ISSUER_ADAPTER_DIDCOMM_PORT=10062
+
+# RP Adapter agent configuration
+RP_ADAPTER_HOST=0.0.0.0
+RP_ADAPTER_PORT=10161
+RP_ADAPTER_DIDCOMM_PORT=10162
+
+# Hydra
+HYDRA_ADMIN_URL=https://hydra.trustbloc.local:4445
+
+# Hydra (RP Adapter)
+RPADAPTER_HYDRA_PUBLIC_PORT=6666
+RPADAPTER_HYDRA_ADMIN_PORT=6667

--- a/test/bdd/fixtures/demo/adapter-config/rp/presentationdefinitions.json
+++ b/test/bdd/fixtures/demo/adapter-config/rp/presentationdefinitions.json
@@ -1,0 +1,42 @@
+{
+  "input_descriptors": [
+    {
+      "id": "banking_input_1",
+      "group": ["scope1"],
+      "schema": {
+        "uri": "https://bank-standards.com/customer.json",
+        "name": "Bank Account Information",
+        "purpose": "We need your bank and account information."
+      },
+      "constraints": {
+        "fields": [
+          {
+            "path": ["$.issuer", "$.vc.issuer", "$.iss"],
+            "purpose": "The credential must be from one of the specified issuers",
+            "filter": {
+              "type": "string",
+              "pattern": "did:example:123|did:example:456"
+            }
+          },
+          {
+            "path": ["$.credentialSubject.account[*].id", "$.vc.credentialSubject.account[*].id"],
+            "purpose": "We need your bank account number for processing purposes",
+            "filter": {
+              "type": "string",
+              "minLength": 10,
+              "maxLength": 12
+            }
+          },
+          {
+            "path": ["$.credentialSubject.account[*].route", "$.vc.credentialSubject.account[*].route"],
+            "purpose": "You must have an account with a German, US, or Japanese bank account",
+            "filter": {
+              "type": "string",
+              "pattern": "^DE|^US|^JP"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/bdd/fixtures/demo/docker-compose-demo-applications.yml
+++ b/test/bdd/fixtures/demo/docker-compose-demo-applications.yml
@@ -19,7 +19,7 @@ services:
       - OAUTH2_ISSUER_CLIENT_ID=auth-code-client
       - OAUTH2_ISSUER_CLIENT_SECRET=secret
       # will access hydra admin through container directly because nginx-proxy doesn't support multiple ports per virtual host
-      - OAUTH2_ENDPOINT_TOKEN_INTROSPECTION_URL=https://hydra.trustbloc.local:4445/oauth2/introspect
+      - OAUTH2_ENDPOINT_TOKEN_INTROSPECTION_URL=${HYDRA_ADMIN_URL}/oauth2/introspect
       - ISSUER_CMS_URL=https://oathkeeper-proxy.trustbloc.local
       - ISSUER_VCS_URL=https://issuer-vcs.trustbloc.local
       # TODO https://github.com/trustbloc/edge-sandbox/issues/392 Expose multiple ports per virtual host
@@ -46,8 +46,10 @@ services:
       - VIRTUAL_HOST=rp.trustbloc.local
     ports:
       - 5557:5557
-    command: start
+    entrypoint: ""
+    command: /bin/bash /tmp/scripts/rp-rest_start.sh
     volumes:
       - ../keys/tls:/etc/tls
+      - ../scripts/:/tmp/scripts
     networks:
       - demo-net

--- a/test/bdd/fixtures/demo/docker-compose-didcomm.yml
+++ b/test/bdd/fixtures/demo/docker-compose-didcomm.yml
@@ -51,3 +51,61 @@ services:
       - ../scripts/:/tmp/scripts
     networks:
       - demo-net
+
+  rp.adapter.rest.example.com:
+    container_name: rp.adapter.rest.example.com
+    image: ${RP_ADAPTER_REST_IMAGE}:${RP_ADAPTER_REST_IMAGE_TAG}
+    environment:
+      - ADAPTER_REST_HOST_URL=${RP_ADAPTER_HOST}:${RP_ADAPTER_PORT}
+      - ADAPTER_REST_TLS_CACERTS=/etc/tls/trustbloc-dev-ca.crt
+      - ADAPTER_REST_TLS_SYSTEMCERTPOOL=true
+      - ADAPTER_REST_DSN=TODO                         # TODO currently unused: https://github.com/trustbloc/edge-adapter/issues/168
+      - ADAPTER_REST_OP_URL=http://TODO.example.com   # TODO currently unused: https://github.com/trustbloc/edge-adapter/issues/24
+      - ADAPTER_REST_PRESENTATION_DEFINITIONS_FILE=/etc/testdata/presentationdefinitions.json
+      - ADAPTER_REST_DIDCOMM_INBOUND_HOST=${RP_ADAPTER_HOST}:${RP_ADAPTER_DIDCOMM_PORT}
+      - ADAPTER_REST_DIDCOMM_INBOUND_HOST_EXTERNAL=https://rp-adapter.trustbloc.local
+      - ADAPTER_REST_TRUSTBLOC_DOMAIN=${BLOC_DOMAIN}
+      - ADAPTER_REST_HYDRA_URL=https://rp-adapter-hydra.trustbloc.local:${RPADAPTER_HYDRA_ADMIN_PORT}
+      - VIRTUAL_HOST=rp-adapter.trustbloc.local
+      - VIRTUAL_PORT=${RP_ADAPTER_DIDCOMM_PORT}
+    ports:
+      - ${RP_ADAPTER_PORT}:${RP_ADAPTER_PORT}
+      - ${RP_ADAPTER_DIDCOMM_PORT}:${RP_ADAPTER_DIDCOMM_PORT}
+    entrypoint: ""
+    command:  /bin/sh -c "adapter-rest start"
+    volumes:
+      - ../keys/tls:/etc/tls
+      - ./adapter-config/rp:/etc/testdata
+    networks:
+      - demo-net
+    depends_on:
+      - hydra
+      - mysql
+
+  rp-adapter-hydra.trustbloc.local:
+    container_name: rp-adapter-hydra.trustbloc.local
+    image: oryd/hydra:v1.3.2-alpine
+    ports:
+      - ${RPADAPTER_HYDRA_PUBLIC_PORT}:${RPADAPTER_HYDRA_PUBLIC_PORT}
+      - ${RPADAPTER_HYDRA_ADMIN_PORT}:${RPADAPTER_HYDRA_ADMIN_PORT}
+    command:  /bin/sh -c "hydra migrate sql --read-from-env --yes; hydra serve all"
+    entrypoint: ""
+    environment:
+      - DSN=mysql://rpadapterhydra:secret@tcp(mysql:3306)/rpadapter_hydra?max_conns=20&max_idle_conns=4
+      - URLS_SELF_ISSUER=https://rp-adapter-hydra.trustbloc.local:${RPADAPTER_HYDRA_PUBLIC_PORT}
+      - URLS_CONSENT=http://rp.adapter.rest.example.com:${RP_ADAPTER_PORT}/consent
+      - URLS_LOGIN=http://rp.adapter.rest.example.com:${RP_ADAPTER_PORT}/login
+      - SECRETS_SYSTEM=testSecretsSystem
+      - OIDC_SUBJECT_TYPES_SUPPORTED=public
+      - OIDC_SUBJECT_TYPE_PAIRWISE_SALT=testSecretsSystem
+      - SERVE_PUBLIC_PORT=${RPADAPTER_HYDRA_PUBLIC_PORT}
+      - SERVE_ADMIN_PORT=${RPADAPTER_HYDRA_ADMIN_PORT}
+      - SERVE_TLS_KEY_PATH=/etc/tls/trustbloc.local.key
+      - SERVE_TLS_CERT_PATH=/etc/tls/trustbloc.local.crt
+    restart: unless-stopped
+    volumes:
+      - ../keys/tls:/etc/tls
+    depends_on:
+      - mysql
+    networks:
+      - demo-net

--- a/test/bdd/fixtures/demo/docker-compose-third-party.yml
+++ b/test/bdd/fixtures/demo/docker-compose-third-party.yml
@@ -87,16 +87,15 @@ services:
 
   mysql:
     container_name: mysql
-    image: mysql:8.0.18
+    image: mysql:8.0.20
     restart: always
     command: --default-authentication-plugin=mysql_native_password
     environment:
-      MYSQL_DATABASE: strapi
-      MYSQL_USER: user
-      MYSQL_PASSWORD: secret
       MYSQL_ROOT_PASSWORD: secret
     logging:
       driver: "none"
+    volumes:
+      - ../scripts/mysql:/docker-entrypoint-initdb.d
     networks:
       - demo-net
 
@@ -123,6 +122,8 @@ services:
           - did-resolver.trustbloc.local
           - consent-login.trustbloc.local
           - issuer.adapter.trustbloc.local
+          - rp.adapter.trustbloc.local
+          - rp-adapter-hydra.trustbloc.local
           - peer0-org1.trustbloc.local
           - peer1-org1.trustbloc.local
           - peer0-org2.trustbloc.local
@@ -154,7 +155,7 @@ services:
     image: ${CONSENT_LOGIN_SERVER_IMAGE}:latest
     environment:
       # will access hydra admin through container directly because nginx-proxy doesn't support multiple ports per virtual host
-      - ADMIN_URL=https://hydra.trustbloc.local:4445
+      - ADMIN_URL=${HYDRA_ADMIN_URL}
       - SERVE_PORT=3300
       - TLS_CACERTS=/etc/tls/trustbloc-dev-ca.crt
       - VIRTUAL_HOST=consent-login.trustbloc.local

--- a/test/bdd/fixtures/scripts/mysql/mysql_configure.sql
+++ b/test/bdd/fixtures/scripts/mysql/mysql_configure.sql
@@ -1,0 +1,17 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+\! echo "Configuring MySQL users...";
+
+-- Strapi
+CREATE USER 'user'@'%' IDENTIFIED BY 'secret';
+CREATE DATABASE strapi;
+GRANT ALL PRIVILEGES ON strapi.* TO 'user'@'%';
+
+-- Hydra (RP Adapter)
+CREATE USER 'rpadapterhydra'@'%' IDENTIFIED BY 'secret';
+CREATE DATABASE rpadapter_hydra;
+GRANT ALL PRIVILEGES ON rpadapter_hydra.* TO 'rpadapterhydra'@'%';

--- a/test/bdd/fixtures/scripts/rp-rest_start.sh
+++ b/test/bdd/fixtures/scripts/rp-rest_start.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+registerRPTenant() {
+    n=0
+    maxAttempts=30
+
+    until [ $n -ge $maxAttempts ]
+    do
+        response=$(curl -o - -s -w "RESPONSE_CODE=%{response_code}" \
+        --header "Content-Type: application/json" \
+        --request POST \
+        --data '{"label": "rp.trustbloc.local", "callback": "https://rp.trustbloc.local/oauth2/callback"}' \
+        http://rp.adapter.rest.example.com:10161/relyingparties)
+
+        code=${response//*RESPONSE_CODE=/}
+
+        if [[ $code -eq 201 ]]
+        then
+            echo "${response}"
+            break
+        fi
+
+        n=$((n+1))
+        if [ $n -eq $maxAttempts ]
+        then
+            echo "Failed to register RP Tenant: $response"
+            break
+        fi
+        sleep 5
+    done
+}
+
+echo "Waiting for the RP Adapter to be ready..."
+# TODO implement a smart healthcheck on RP Adapter: https://github.com/trustbloc/edge-adapter/issues/134
+sleep 30
+echo "Registering RP Adapter tenant..."
+result=$(registerRPTenant)
+registration=${result//RESPONSE_CODE*/}
+code=${result//*RESPONSE_CODE=/}
+if [ $code -ne 201 ]
+then
+    echo "Failed to register RP Tenant!"
+    echo "   HTTP STATUS CODE: $code"
+    echo "   HTTP RESPONSE: $registration"
+    exit 1
+fi
+echo "RP Tenant ClientID=$(echo $registration | jq .clientID) PublicDID=$(echo $registration | jq .publicDID)."
+echo ""
+
+echo "Starting rp.example.com..."
+# TODO OAuth2 configuration for rp.example.com https://github.com/trustbloc/edge-sandbox/issues/399
+rp-rest start


### PR DESCRIPTION
closes #397 

A second instance of Hydra is added because Hydra does not support more than one login and consent app. This instance is configured to use the same `mysql` instance. The latter has been configured to execute an sql script at startup that creates users and databases for strapi and this new hydra instance.

Signed-off-by: George Aristy <george.aristy@securekey.com>