### PR TITLE
feat: DIDComm Credential API for Issuer Adapter

### DIFF
--- a/cmd/issuer-rest/startcmd/start.go
+++ b/cmd/issuer-rest/startcmd/start.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/trustbloc/edge-core/pkg/log"
 	"github.com/trustbloc/edge-core/pkg/restapi/logspec"
+	"github.com/trustbloc/edge-core/pkg/storage/memstore"
 	cmdutils "github.com/trustbloc/edge-core/pkg/utils/cmd"
 	tlsutils "github.com/trustbloc/edge-core/pkg/utils/tls"
 	"golang.org/x/oauth2"
@@ -345,6 +346,8 @@ func startIssuer(parameters *issuerParameters) error {
 		TLSConfig:        tlsConfig,
 		RequestTokens:    parameters.requestTokens,
 		IssuerAdapterURL: parameters.issuerAdapterURL,
+		// TODO https://github.com/trustbloc/edge-sandbox/issues/408 configure database
+		StoreProvider: memstore.NewProvider(),
 	}
 
 	issuerService, err := issuer.New(cfg)

--- a/cmd/issuer-rest/static/index.html
+++ b/cmd/issuer-rest/static/index.html
@@ -61,7 +61,7 @@ SPDX-License-Identifier: Apache-2.0
         <div class="w-full flex-grow lg:flex lg:items-center lg:w-auto hidden lg:block mt-2 lg:mt-0 bg-white lg:bg-transparent text-black p-4 lg:p-0 z-20" id="nav-content">
             <ul class="list-reset lg:flex justify-end flex-1 items-center">
                 <li class="mr-3">
-                    <a href="/login?scope=CreditCardStatement&vcsProfile=didComm" class="inline-block text-black no-underline hover:text-green hover:text-underline py-2 px-4">
+                    <a href="/login?scope=CreditCardStatement&vcsProfile=trustbloc-ed25519signature2018-ed25519&demoType=DIDComm" class="inline-block text-black no-underline hover:text-green hover:text-underline py-2 px-4">
                         DIDComm Flow</a>
                 </li>
                 <li class="mr-3">

--- a/pkg/restapi/issuer/controller.go
+++ b/pkg/restapi/issuer/controller.go
@@ -14,7 +14,11 @@ import (
 func New(config *operation.Config) (*Controller, error) {
 	var allHandlers []operation.Handler
 
-	issuerService := operation.New(config)
+	issuerService, err := operation.New(config)
+	if err != nil {
+		return nil, err
+	}
+
 	allHandlers = append(allHandlers, issuerService.GetRESTHandlers()...)
 
 	return &Controller{handlers: allHandlers}, nil

--- a/pkg/restapi/issuer/controller_test.go
+++ b/pkg/restapi/issuer/controller_test.go
@@ -7,24 +7,37 @@ SPDX-License-Identifier: Apache-2.0
 package issuer
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	mockstorage "github.com/trustbloc/edge-core/pkg/storage/mockstore"
 
 	"github.com/trustbloc/edge-sandbox/pkg/restapi/issuer/operation"
 )
 
 func TestController_New(t *testing.T) {
-	controller, err := New(&operation.Config{})
-	require.NoError(t, err)
-	require.NotNil(t, controller)
+	t.Run("test new - success", func(t *testing.T) {
+		controller, err := New(&operation.Config{StoreProvider: &mockstorage.Provider{}})
+		require.NoError(t, err)
+		require.NotNil(t, controller)
+	})
+
+	t.Run("test new - error", func(t *testing.T) {
+		controller, err := New(&operation.Config{
+			StoreProvider: &mockstorage.Provider{ErrCreateStore: errors.New("store create error")},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "issuer store provider : store create error")
+		require.Nil(t, controller)
+	})
 }
 
 func TestController_GetOperations(t *testing.T) {
-	controller, err := New(&operation.Config{})
+	controller, err := New(&operation.Config{StoreProvider: &mockstorage.Provider{}})
 	require.NoError(t, err)
 	require.NotNil(t, controller)
 
 	ops := controller.GetOperations()
-	require.Equal(t, 5, len(ops))
+	require.Equal(t, 6, len(ops))
 }

--- a/test/bdd/fixtures/scripts/strapi_configure.sh
+++ b/test/bdd/fixtures/scripts/strapi_configure.sh
@@ -48,7 +48,7 @@ GENERATE_UDC_COMMAND="strapi generate:api universitydegreecredentials UserID:str
 $GENERATE_UDC_COMMAND
 
 # generate the creditcardstatements and model
-GENERATE_CCS_COMMAND="strapi generate:api creditcardstatements UserID:string VcMetadata:json Statement:json"
+GENERATE_CCS_COMMAND="strapi generate:api creditcardstatements UserID:string VcMetadata:json stmt:json"
 
 $GENERATE_CCS_COMMAND
 
@@ -168,7 +168,7 @@ fi
 # Add creditcardstatements data for above created user
 result=$(curl --header "Content-Type: application/json" --header "Authorization: Bearer $token" \
    --request POST \
-   --data '{ "userid":"100", "vcmetadata":{ "@context": "http://schema.org/", "@type": "Invoice", "description": "June 2020 Credit Card Statement", "url": "http://acmebank.com/invoice.pdf", "broker": { "@type": "BankOrCreditUnion", "name": "ACME Bank" }, "accountId": "xxxx-xxxx-xxxx-1234", "customer": { "@type": "Person", "name": "Jane Doe" }, "paymentDueDate": "2020-06-30T12:00:00", "minimumPaymentDue": { "@type": "PriceSpecification", "price": 15.00, "priceCurrency": "CAD" }, "totalPaymentDue": { "@type": "PriceSpecification", "price": 200.00, "priceCurrency": "CAD" }, "billingPeriod": "P30D", "paymentStatus": "http://schema.org/PaymentDue" }}' \
+   --data '{"userid":"100","vcmetadata":{"@context":["https://www.w3.org/2018/credentials/v1","https://trustbloc.github.io/context/vc/examples-ext-v1.jsonld"],"name":"Credit Card Statement","description":"Credit Card Statement of Mr.John Smith"},"stmt":{"description":"June 2020 CreditCardStatement","url":"http://acmebank.com/invoice.pdf","accountId":"xxxx-xxxx-xxxx-1234","customer":{"@type":"Person","name":"Jane Doe"},"paymentDueDate":"2020-06-30T12:00:00","minimumPaymentDue":{"@type":"PriceSpecification","price":15.00,"priceCurrency":"CAD"},"totalPaymentDue":{"@type":"PriceSpecification","price":200.00,"priceCurrency":"CAD"},"billingPeriod":"P30D","paymentStatus":"http://schema.org/PaymentDue"}}' \
    http://strapi:1337/creditcardstatements | jq  -r ".error")
 # check for error
 if [ "$result" != "null" ]


### PR DESCRIPTION
- Save state sent in issuer adapter call and validate in callback handler
- Save token received in issuer adapter callback handler
- Validate token in credential api and send credential back to issuer adapter

closes #406 

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>