### PR TITLE
fix: rp.example.com not starting

### DIFF
--- a/test/bdd/fixtures/demo/.env
+++ b/test/bdd/fixtures/demo/.env
@@ -76,7 +76,7 @@ ARIES_AGENT_REST_IMAGE_TAG=amd64-0.1.4-snapshot-04c2d61
 ISSUER_ADAPTER_REST_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/issuer-adapter-rest
 ISSUER_ADAPTER_REST_IMAGE_TAG=0.1.4-snapshot-65ac40d
 RP_ADAPTER_REST_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/rp-adapter-rest
-RP_ADAPTER_REST_IMAGE_TAG=0.1.4-snapshot-17dfed6
+RP_ADAPTER_REST_IMAGE_TAG=0.1.4-snapshot-65ac40d
 
 # Transport Schemes
 HTTP_SCHEME=http


### PR DESCRIPTION
Previous update of sidetree broke rp-adapter <-> trustbloc-did-method
integration

Signed-off-by: George Aristy <george.aristy@securekey.com>