### PR TITLE
fix: remove hard-coded rp adapter startup delay

### DIFF
--- a/test/bdd/fixtures/demo/docker-compose-didcomm.yml
+++ b/test/bdd/fixtures/demo/docker-compose-didcomm.yml
@@ -82,7 +82,7 @@ services:
       - ${RP_ADAPTER_PORT}:${RP_ADAPTER_PORT}
       - ${RP_ADAPTER_DIDCOMM_PORT}:${RP_ADAPTER_DIDCOMM_PORT}
     entrypoint: ""
-    command:  /bin/sh -c "sleep 20;adapter-rest start"
+    command:  /bin/sh -c "adapter-rest start"
     volumes:
       - ../keys/tls:/etc/tls
       - ./adapter-config/rp:/etc/testdata


### PR DESCRIPTION
The RP Adapter already has [retry logic](https://github.com/trustbloc/edge-adapter/blob/11050878d9d0fb6c0a7bd0b28df7e68d2af4c233/cmd/adapter-rest/startcmd/start.go#L648-L689).

Signed-off-by: George Aristy <george.aristy@securekey.com>