### PR TITLE
feat: demo of mixed local+remote credentials

### DIFF
--- a/cmd/issuer-rest/static/creditscore.html
+++ b/cmd/issuer-rest/static/creditscore.html
@@ -89,10 +89,10 @@ SPDX-License-Identifier: Apache-2.0
                 <img class="object-contain h-64 w-full" src="img/credit_score.jpg">
                 <div class="flex justify-center mt-8 pt-2">
                     <form id="didCommDemo"  action="">
-                        <input type="text" id="demoType" name="scope" value="" checked hidden>
-                        <input type="text" id="didCommScope" name="demoType" value="" checked hidden>
+                        <input type="text" id="demoType" name="demoType" value="" checked hidden>
+                        <input type="text" id="didCommScope" name="didCommScope" value="" checked hidden>
                         <input type="text" id="adapterProfile" name="adapterProfile" value="" checked hidden>
-                        <input type="submit"id="creditScore" class="lg:mx-0 hover:underline gradient text-white font-bold my-6 py-4 px-8 shadow-lg" value="Get your credit report">
+                        <input type="submit" id="creditScore" class="lg:mx-0 hover:underline gradient text-white font-bold my-6 py-4 px-8 shadow-lg" value="Get your credit report">
                     </form>
                 </div>
             </div>

--- a/cmd/issuer-rest/static/drivinglicense.html
+++ b/cmd/issuer-rest/static/drivinglicense.html
@@ -99,9 +99,9 @@ SPDX-License-Identifier: Apache-2.0
                 <div class="flex justify-center mt-8 pt-2">
                     <form id="didCommDemo"  action="">
                         <input type="text" id="demoType" name="demoType" value="" checked hidden>
-                        <input type="text" id="didCommScope" name="didCommScope" value="" checked hidden>
-                        <input type="text" id="adapterProfile" name="adapterProfile" value="" checked hidden>
-                        <input type="submit"id="drivingLicense" class="lg:mx-0 hover:underline gradient text-white font-bold my-6 py-4 px-8 shadow-lg" value="Issue Driving License">
+                        <input type="text" id="vcsProfile" name="vcsProfile" value="" checked hidden>
+                        <input type="text" id="scope" name="scope" value="" checked hidden>
+                        <input type="submit" id="drivingLicense" class="lg:mx-0 hover:underline gradient text-white font-bold my-6 py-4 px-8 shadow-lg" value="Issue Driving License">
                     </form>
                 </div>
             </div>

--- a/cmd/issuer-rest/static/js/action.js
+++ b/cmd/issuer-rest/static/js/action.js
@@ -66,9 +66,9 @@ $(document).ready(function () {
 
     $('#drivingLicense').on('click', function() {
         if (!$(this).data('clicked')) {
-            $('#demoType').val("DIDComm");
-            $('#didCommScope').val("mDL");
-            $('#adapterProfile').val("tb-dl-issuer");
+            $('#demoType').val("nonDIDComm");
+            $('#vcsProfile').val("trustbloc-jsonwebsignature2020-p256");
+            $('#scope').val("mDL");
             $(this).data('clicked', true);
         }
     });

--- a/cmd/rp-rest/static/bankaccount.html
+++ b/cmd/rp-rest/static/bankaccount.html
@@ -203,7 +203,7 @@ SPDX-License-Identifier: Apache-2.0
         console.log("Receiving presentation from wallet")
         axios({
             method: "GET",
-            url: "/oauth2/request?scope=driver_license:local"
+            url: "/oauth2/request?scope=driver_license:local credit_score:remote"
         }).then(
             resp => {window.location.href = resp.data.request},
             err => console.error(err)

--- a/pkg/restapi/rp/operation/operations.go
+++ b/pkg/restapi/rp/operation/operations.go
@@ -16,6 +16,7 @@ import (
 	"html/template"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/coreos/go-oidc"
 	"github.com/google/uuid"
@@ -252,7 +253,7 @@ func (c *Operation) createOIDCRequest(w http.ResponseWriter, r *http.Request) {
 	// TODO validate scope
 
 	state := uuid.New().String()
-	redirectURL := c.oauth2Config(scope).AuthCodeURL(state, oauth2.AccessTypeOnline)
+	redirectURL := c.oauth2Config(strings.Split(scope, " ")...).AuthCodeURL(state, oauth2.AccessTypeOnline)
 
 	logger.Debugf("redirectURL: %s", redirectURL)
 

--- a/test/bdd/fixtures/scripts/didcomm/issuer_adapter_configure.sh
+++ b/test/bdd/fixtures/scripts/didcomm/issuer_adapter_configure.sh
@@ -15,7 +15,7 @@ until [ $n -ge $maxAttempts ]
 do
    responseCreatedTime=$(curl -k --header "Content-Type: application/json" \
    --request POST \
-   --data '{"id":"tb-cc-issuer", "name":"TrustBloc - Credit Card Data Issuer", "url":"https://issuer.trustbloc.local/didcomm", "supportedVCContexts" : ["https://trustbloc.github.io/context/vc/examples/credit-card-v1.jsonld"]}' \
+   --data '{"id":"tb-cc-issuer", "name":"TrustBloc - Credit Card Data Issuer", "url":"https://issuer.trustbloc.local/didcomm", "supportedVCContexts" : ["https://trustbloc.github.io/context/vc/examples/credit-card-v1.jsonld","https://trustbloc.github.io/context/vc/examples/credit-score-v1.jsonld"]}' \
    https://issuer.adapter.rest.example.com:10061/profile | jq -r '.createdAt' 2>/dev/null)
    echo "'created' field from profile tb-cc-issuer response is: $responseCreatedTime"
 

--- a/test/bdd/fixtures/scripts/rp-rest_start.sh
+++ b/test/bdd/fixtures/scripts/rp-rest_start.sh
@@ -19,7 +19,7 @@ registerRPTenant() {
         response=$(curl -k -o - -s -w "RESPONSE_CODE=%{response_code}" \
         --header "Content-Type: application/json" \
         --request POST \
-        --data '{"label": "rp.trustbloc.local", "callback": "'$callbackURL'", "scopes": ["credit_card_stmt:remote","driver_license:local"]}' \
+        --data '{"label": "rp.trustbloc.local", "callback": "'$callbackURL'", "scopes": ["credit_card_stmt:remote","driver_license:local","credit_score:remote"]}' \
         $rpAdapterURL)
 
         code=${response//*RESPONSE_CODE=/}

--- a/test/bdd/fixtures/scripts/strapi_configure.sh
+++ b/test/bdd/fixtures/scripts/strapi_configure.sh
@@ -53,12 +53,12 @@ GENERATE_CCS_COMMAND="strapi generate:api creditcardstatements UserID:string met
 $GENERATE_CCS_COMMAND
 
 # generate the drivinglicenses and model
-GENERATE_DL_COMMAND="strapi generate:api mdls UserID:string metadata:json data:json"
+GENERATE_DL_COMMAND="strapi generate:api mdls UserID:string VcMetadata:json Name:string Degree:json"
 
 $GENERATE_DL_COMMAND
 
 # generate the drivinglicenses and model
-GENERATE_CS_COMMAND="strapi generate:api creditscores UserID:string VcMetadata:json VcCredentialSubject:json"
+GENERATE_CS_COMMAND="strapi generate:api creditscores UserID:string metadata:json data:json"
 
 $GENERATE_CS_COMMAND
 
@@ -190,18 +190,18 @@ fi
 # Add driving license data for above created user.
 result=$(curl --header "Content-Type: application/json" --header "Authorization: Bearer $token" \
    --request POST \
-   --data '{"userid":"100","metadata": {"contexts":["https://trustbloc.github.io/context/vc/examples/mdl-v1.jsonld"],"scopes":["mDL"]},"data":{"given_name": "John", "family_name": "Smith", "document_number": "123-456-789"}}' \
-    http://strapi:1337/mdls | jq  -r ".error")
+   --data '{"userid":"100","vcmetadata":{"@context":["https://www.w3.org/2018/credentials/v1","https://trustbloc.github.io/context/vc/examples/mdl-v1.jsonld"],"name":"Driving License","description":"Driving License for John Smith"},"vccredentialsubject":{"given_name": "John", "family_name": "Smith", "document_number": "123-456-789"}}' \
+   http://strapi:1337/mdls | jq  -r ".error")
 # check for error
 if [ "$result" != "null" ]
    then
-        echo "error insert mDL data in strapi: $result"
+        echo "error insert mdls data in strapi: $result"
 fi
 
 # Add credit score data for above created user.
 result=$(curl --header "Content-Type: application/json" --header "Authorization: Bearer $token" \
    --request POST \
-   --data '{"userid":"100","vcmetadata":{"@context":["https://www.w3.org/2018/credentials/v1","https://trustbloc.github.io/context/vc/examples/credit-score-v1.jsonld"],"name":"Credit Score Report","description":"Credit Score Report for John Doe"},"vccredentialsubject":{"family_name":"Doe","given_name":"John","birthdate":"1990-01-01","address":"4726 Pine Street, Toronto - A1B 2C3","report_date":"2020-08-14","score":"737","provider_name":"Acme Inc", "type":"CreditScore"}}' \
+   --data '{"userid":"100","metadata":{"contexts":["https://trustbloc.github.io/context/vc/examples/credit-score-v1.jsonld"],"scopes":["CreditScore"]},"data":{"family_name":"Doe","given_name":"John","birthdate":"1990-01-01","address":"4726 Pine Street, Toronto - A1B 2C3","report_date":"2020-08-14","score":"737"}}' \
    http://strapi:1337/creditscores | jq  -r ".error")
 # check for error
 if [ "$result" != "null" ]


### PR DESCRIPTION
This PR showcases a requesting party obtaining a local and a remote credential simultaneously. The local credential is a driving license and the remote credential is the credit score. 

(TODO: the RP's final "verification success" page does not yet show the data being received (@talwinder50 ))

**Test procedures:**

1. Go to `https://myagent.trustbloc.local/dashboard` and login/register your wallet
   * Create a public DID if you haven't already
   * Register your router (`https://router.trustbloc.local`) if you haven't already
2. Go to `https://issuer.trustbloc.local/drivinglicense` and obtain your DL credential via CHAPI
   * **don't forget to save your credential to your wallet at the end!**
3. Go to `https://issuer.trustbloc.local/creditscore` and connect with this issuer. This will result in an [IssuerManifestCredential](https://github.com/trustbloc/context/blob/master/vc/issuer-manifest-credential-v1.jsonld) stored in your wallet *via didcomm*.
4. Go to `https://rp.trustbloc.local/bankaccount` and perform the flow. Two credentials will be requested in the CHAPI prompt. You should see a "Driving License" credential and a "TrustBloc - Credit Card Data Issuer" credential that you can select. Then click on `Share`
5. You should end up back at `https://rp.trustbloc.local` with a message "Presented Digital ID Successfully Verified"

**Fixes:**

* fix: incorrect data and form setup for driving license
* fix: incorrect data  setup for the credit score
* fix: parsing scope array by rp.example.com backend

Signed-off-by: George Aristy <george.aristy@securekey.com>