### PR TITLE
fix: #506 incorrect DL data setup

### DIFF
--- a/test/bdd/fixtures/scripts/strapi_configure.sh
+++ b/test/bdd/fixtures/scripts/strapi_configure.sh
@@ -53,7 +53,7 @@ GENERATE_CCS_COMMAND="strapi generate:api creditcardstatements UserID:string met
 $GENERATE_CCS_COMMAND
 
 # generate the drivinglicenses and model
-GENERATE_DL_COMMAND="strapi generate:api mdls UserID:string VcMetadata:json Name:string Degree:json"
+GENERATE_DL_COMMAND="strapi generate:api mdls UserID:string VcMetadata:json Name:string VcCredentialSubject:json"
 
 $GENERATE_DL_COMMAND
 


### PR DESCRIPTION
part of #506 

The CMS DL API definition was mismatched against the schema of the data, we ended up with `degree: null` in the issuer's page.

Here's how it looks now:

![image](https://user-images.githubusercontent.com/2019896/91167061-50ec2d80-e6a1-11ea-88d2-7f024ef75c3c.png)

Here's how it looked before:

![image](https://user-images.githubusercontent.com/2019896/91167204-8a249d80-e6a1-11ea-92b0-742dc3a24052.png)


Signed-off-by: George Aristy <george.aristy@securekey.com>