### PR TITLE
fix: Setting Default loading icon display to none

### DIFF
--- a/cmd/rp-rest/static/index.html
+++ b/cmd/rp-rest/static/index.html
@@ -110,7 +110,7 @@ SPDX-License-Identifier: Apache-2.0
 <!-- start what would you like to do -->
 <section class="bg-white border-b py-2">
       <div class="container justify-center mx-auto flex flex-wrap">
-        <div class="w-full h-full fixed top-0 left-0 bg-black opacity-75 z-50" id="loading-screen" style="display:block">
+        <div class="w-full h-full fixed top-0 left-0 bg-black opacity-75 z-50" id="loading-screen" style="display:none">
         <span class="text-green-500 opacity-75 top-1/2 my-0 mx-auto block relative w-0 h-0" style="top: 50%;">
          <i class="fas fa-circle-notch fa-spin fa-5x"></i>
        </span>


### PR DESCRIPTION
Signed-off-by: talwinder.kaur <talwinder.kaur@securekey.com>