### PR TITLE
chore: Update hub-router and issuer/rp-adapter docker image update

### DIFF
--- a/test/bdd/fixtures/demo/.env
+++ b/test/bdd/fixtures/demo/.env
@@ -76,7 +76,7 @@ HTTP_RESOLVER=trustbloc@https://did-resolver.trustbloc.local/1.0/identifiers,v1@
 # ------------------- DIDComm -------------------
 # Aries Router configurations
 HUB_ROUTER_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/hub-router
-HUB_ROUTER_IMAGE_TAG=0.1.5-snapshot-e72930d
+HUB_ROUTER_IMAGE_TAG=0.1.5-snapshot-876269d
 DIDCOMM_ROUTER_HOST=0.0.0.0
 DIDCOMM_ROUTER_HTTP_INBOUND_PORT=9081
 DIDCOMM_ROUTER_WS_INBOUND_PORT=9082
@@ -84,14 +84,14 @@ DIDCOMM_ROUTER_API_PORT=9084
 
 # Issuer adapter
 ISSUER_ADAPTER_REST_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/issuer-adapter-rest
-ISSUER_ADAPTER_REST_IMAGE_TAG=0.1.5-snapshot-ebc87e2
+ISSUER_ADAPTER_REST_IMAGE_TAG=0.1.5-snapshot-ea84459
 ISSUER_ADAPTER_HOST=0.0.0.0
 ISSUER_ADAPTER_PORT=10061
 ISSUER_ADAPTER_DIDCOMM_PORT=10062
 
 # RP Adapter
 RP_ADAPTER_REST_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/rp-adapter-rest
-RP_ADAPTER_REST_IMAGE_TAG=0.1.5-snapshot-ebc87e2
+RP_ADAPTER_REST_IMAGE_TAG=0.1.5-snapshot-ea84459
 RP_ADAPTER_HOST=0.0.0.0
 RP_ADAPTER_PORT=10161
 RP_ADAPTER_DIDCOMM_PORT=10162


### PR DESCRIPTION
Hub router:
- Aries Go update https://github.com/trustbloc/hub-router/pull/29
- Support for Blinded routing https://github.com/trustbloc/hub-router/issues/23

Edge adapter:
- Aries Go update https://github.com/trustbloc/edge-adapter/pull/338

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>