### PR TITLE
chore: update user agent image to the latest version

### DIFF
--- a/scripts/generate_test_keys.sh
+++ b/scripts/generate_test_keys.sh
@@ -24,6 +24,7 @@ mkdir -p test/bdd/fixtures/keys/update2-org2
 mkdir -p test/bdd/fixtures/keys/recover-org3
 mkdir -p test/bdd/fixtures/keys/update-org3
 mkdir -p test/bdd/fixtures/keys/update2-org3
+mkdir -p test/bdd/fixtures/keys/session_cookies
 
 localhostSSLConf=$(mktemp)
 echo "subjectKeyIdentifier=hash
@@ -95,5 +96,9 @@ openssl ecparam -name prime256v1 -genkey -noout -out test/bdd/fixtures/keys/upda
 openssl ec -in test/bdd/fixtures/keys/update-org3/key.pem -pubout -out test/bdd/fixtures/keys/update-org3/public.pem
 openssl ecparam -name prime256v1 -genkey -noout -out test/bdd/fixtures/keys/update2-org3/key.pem
 openssl ec -in test/bdd/fixtures/keys/update2-org3/key.pem -pubout -out test/bdd/fixtures/keys/update2-org3/public.pem
+
+# create session cookie keys
+openssl rand -out test/bdd/fixtures/keys/session_cookies/auth.key 32
+openssl rand -out test/bdd/fixtures/keys/session_cookies/enc.key 32
 
 echo "done generating edge-sandbox PKI"

--- a/test/bdd/fixtures/demo/.env
+++ b/test/bdd/fixtures/demo/.env
@@ -13,7 +13,7 @@ CONSENT_LOGIN_SERVER_IMAGE=docker.pkg.github.com/trustbloc/edge-sandbox/login-co
 
 # Edge agent
 USER_AGENT_WASM_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/user-agent-wasm
-USER_AGENT_WASM_IMAGE_TAG=0.1.5-snapshot-9cd238b
+USER_AGENT_WASM_IMAGE_TAG=0.1.5-snapshot-daaec8e
 WALLET_ROUTER_URL=https://router.trustbloc.local:9084
 
 # Edge service

--- a/test/bdd/fixtures/demo/docker-compose-edge-components.yml
+++ b/test/bdd/fixtures/demo/docker-compose-edge-components.yml
@@ -191,11 +191,13 @@ services:
       - HTTP_SERVER_OIDC_CLIENTID=TODO
       - HTTP_SERVER_OIDC_CLIENTSECRET=TODO
       - HTTP_SERVER_OIDC_CALLBACK=http://TODO.com/callback
-      - TLS_CACERTS=/etc/tls/trustbloc-dev-ca.crt
+      - TLS_CACERTS=/etc/keys/tls/trustbloc-dev-ca.crt
+      - HTTP_SERVER_COOKIE_AUTH_KEY=/etc/keys/session_cookies/auth.key
+      - HTTP_SERVER_COOKIE_ENC_KEY=/etc/keys/session_cookies/enc.key
     ports:
       - 8091:8091
     volumes:
-      - ../keys/tls:/etc/tls
+      - ../keys:/etc/keys
     command: start
     depends_on:
       - rp-adapter-hydra.trustbloc.local


### PR DESCRIPTION
This PR updates the user agent image to the latest version (0.1.5-snapshot-daaec8e) and accommodates to the appropriate changes in the agent (addition of session cookies by [this commit](https://github.com/trustbloc/edge-agent/commit/1ed0de50ae1f33c21669d497c7e831e330c6f923)).

Signed-off-by: Andriy Holovko <andriy.holovko@gmail.com>