### PR TITLE
fix: Changes domain (myagent.support)

### DIFF
--- a/scripts/trustbloc_local_setup.sh
+++ b/scripts/trustbloc_local_setup.sh
@@ -16,7 +16,7 @@ cat > ${SANDBOX_HOME}/hosts <<EOF
 127.0.0.1 issuer.trustbloc.local
 127.0.0.1 cms.trustbloc.local
 127.0.0.1 myagent.trustbloc.local
-127.0.0.1 myagent.support.trustbloc.local
+127.0.0.1 myagent-support.trustbloc.local
 127.0.0.1 router.trustbloc.local
 127.0.0.1 hydra.trustbloc.local
 127.0.0.1 consent-login.trustbloc.local

--- a/test/bdd/fixtures/demo/docker-compose-edge-components.yml
+++ b/test/bdd/fixtures/demo/docker-compose-edge-components.yml
@@ -182,11 +182,11 @@ services:
     environment:
       - AGENT_UI_URL=https://myagent.trustbloc.local
       - HTTP_SERVER_HOST_URL=0.0.0.0:8092
-      - VIRTUAL_HOST=myagent.support.trustbloc.local
+      - VIRTUAL_HOST=myagent-support.trustbloc.local
       - HTTP_SERVER_OIDC_OPURL=https://auth-rest-hydra.trustbloc.local:11201/
       - HTTP_SERVER_OIDC_CLIENTID=user-agent
       - HTTP_SERVER_OIDC_CLIENTSECRET=user-agent-secret
-      - HTTP_SERVER_OIDC_CALLBACK=https://myagent.support.trustbloc.local/oidc/callback
+      - HTTP_SERVER_OIDC_CALLBACK=https://myagent-support.trustbloc.local/oidc/callback
       - HTTP_SERVER_DEP_MAXRETRIES=180
       - HTTP_SERVER_COOKIE_AUTH_KEY=/etc/keys/session_cookies/auth.key
       - HTTP_SERVER_COOKIE_ENC_KEY=/etc/keys/session_cookies/enc.key
@@ -225,7 +225,7 @@ services:
       - HTTP_RESOLVER_URL=${HTTP_RESOLVER}
       - AGENT_DEFAULT_LABEL=user-agent
       - BLOC_DOMAIN=${BLOC_DOMAIN}
-      - EDGE_AGENT_SERVER=https://myagent.support.trustbloc.local
+      - EDGE_AGENT_SERVER=https://myagent-support.trustbloc.local
       - WALLET_MEDIATOR_URL=${WALLET_ROUTER_URL}
       - BLINDED_ROUTING=${SUPPORT_BLINDED_ROUTING}
       - STORAGE_TYPE=indexedDB

--- a/test/bdd/fixtures/demo/docker-compose-third-party.yml
+++ b/test/bdd/fixtures/demo/docker-compose-third-party.yml
@@ -143,7 +143,7 @@ services:
           - authz-kms.trustbloc.local
           - ops-kms.trustbloc.local
           - myagent.trustbloc.local
-          - myagent.support.trustbloc.local
+          - myagent-support.trustbloc.local
 
   shared.couchdb:
     container_name: shared.couchdb

--- a/test/bdd/fixtures/scripts/hydra/auth-rest-hydra_configure.sh
+++ b/test/bdd/fixtures/scripts/hydra/auth-rest-hydra_configure.sh
@@ -16,5 +16,5 @@ hydra clients create \
     --response-types code,id_token \
     --scope openid,profile,email \
     --skip-tls-verify \
-    --callbacks https://myagent.support.trustbloc.local/oidc/callback
+    --callbacks https://myagent-support.trustbloc.local/oidc/callback
 echo "Finish Creating client"


### PR DESCRIPTION
Changes domain `myagent.support` to `myagent-support` due to issue `ERR_CERT_COMMON_NAME_INVALID`.

Signed-off-by: Andrii Soluk <isoluchok@gmail.com>