### PR TITLE
feat: enable oathkeeper for hub-kms

### DIFF
--- a/scripts/trustbloc_local_setup.sh
+++ b/scripts/trustbloc_local_setup.sh
@@ -42,4 +42,8 @@ cat > ${SANDBOX_HOME}/hosts <<EOF
 127.0.0.1 shared.couchdb
 127.0.0.1 auth-rest.trustbloc.local
 127.0.0.1 auth-rest-hydra.trustbloc.local
+127.0.0.1 oathkeeper-auth-keyserver.trustbloc.local
+127.0.0.1 oathkeeper-ops-keyserver.trustbloc.local
+127.0.0.1 ops-kms.trustbloc.local
 EOF
+# TODO remove ops-kms.trustbloc.local after this is fixed: https://github.com/trustbloc/edge-agent/issues/574.

--- a/test/bdd/fixtures/demo/.env
+++ b/test/bdd/fixtures/demo/.env
@@ -13,9 +13,9 @@ CONSENT_LOGIN_SERVER_IMAGE=docker.pkg.github.com/trustbloc/edge-sandbox/login-co
 
 # Edge agent
 USER_AGENT_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/wallet-web
-USER_AGENT_IMAGE_TAG=0.1.5-snapshot-268c929
+USER_AGENT_IMAGE_TAG=0.1.5-snapshot-1da8aef
 USER_AGENT_SUPPORT_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/wallet-server
-USER_AGENT_SUPPORT_IMAGE_tag=0.1.5-snapshot-268c929
+USER_AGENT_SUPPORT_IMAGE_tag=0.1.5-snapshot-1da8aef
 WALLET_ROUTER_URL=https://router.trustbloc.local:9084
 SUPPORT_BLINDED_ROUTING=true
 

--- a/test/bdd/fixtures/demo/docker-compose-edge-components.yml
+++ b/test/bdd/fixtures/demo/docker-compose-edge-components.yml
@@ -208,8 +208,8 @@ services:
       - HTTP_SERVER_RP_DISPLAY_NAME=trustbloc
       - HTTP_SERVER_RP_ORIGIN_NAME=https://myagent.trustbloc.local
       - HTTP_SERVER_RP_ID=myagent.trustbloc.local
-      - HTTP_SERVER_AUTHZ_KMS_URL=https://authz-kms.trustbloc.local
-      - HTTP_SERVER_OPS_KMS_URL=https://ops-kms.trustbloc.local
+      - HTTP_SERVER_AUTHZ_KMS_URL=https://oathkeeper-auth-keyserver.trustbloc.local
+      - HTTP_SERVER_OPS_KMS_URL=https://oathkeeper-ops-keyserver.trustbloc.local
       - HTTP_SERVER_KEY_EDV_URL=https://edv-oathkeeper-proxy.trustbloc.local/encrypted-data-vaults
       - HTTP_SERVER_USER_EDV_URL=https://edv-oathkeeper-proxy.trustbloc.local/encrypted-data-vaults
     ports:
@@ -264,8 +264,8 @@ services:
     networks:
       - demo-net
 
-  authz-kms.rest.example.com:
-    container_name: authz-kms.rest.example.com
+  authz-kms-rest.example.com:
+    container_name: authz-kms-rest.example.com
     image: ${KMS_REST_IMAGE}:${KMS_REST_TAG}
     environment:
       - KMS_HOST_URL=0.0.0.0:8072
@@ -354,8 +354,8 @@ services:
       - AUTH_REST_LOG_LEVEL=DEBUG
       - AUTH_REST_SDS_DOCS_URL=https://TODO.docs.sds.org/
       - AUTH_REST_SDS_OPSKEYS_URL=https://TODO.keys.sds.org/
-      - AUTH_REST_KEYSERVER_AUTH_URL=https://TODO.auth.keyserver.org/
-      - AUTH_REST_KEYSERVER_OPS_URL=https://TODO.ops.keyserver.org/
+      - AUTH_REST_KEYSERVER_AUTH_URL=https://oathkeeper-auth-keyserver.trustbloc.local
+      - AUTH_REST_KEYSERVER_OPS_URL=https://oathkeeper-ops-keyserver.trustbloc.local
       - AUTH_REST_COOKIE_AUTH_KEY=/etc/keys/session_cookies/auth.key
       - AUTH_REST_COOKIE_ENC_KEY=/etc/keys/session_cookies/enc.key
       - AUTH_REST_API_TOKEN=authkms-token

--- a/test/bdd/fixtures/demo/docker-compose-third-party.yml
+++ b/test/bdd/fixtures/demo/docker-compose-third-party.yml
@@ -88,6 +88,52 @@ services:
     networks:
       - demo-net
 
+  oathkeeper-auth-keyserver.trustbloc.local:
+    container_name: oathkeeper-auth-keyserver.trustbloc.local
+    image: oryd/oathkeeper:v0.38.4-alpine
+    ports:
+      - 4459:4459
+    command: /bin/sh -c "cp /etc/tls/trustbloc-dev-ca.crt /usr/local/share/ca-certificates/;update-ca-certificates;oathkeeper serve proxy --config /oathkeeper/config.yaml"
+    user: root
+    entrypoint: ""
+    environment:
+      - LOG_LEVEL=debug
+      - PORT=4459
+      - ISSUER_URL=https://oathkeeper-proxy.trustbloc.local
+      - SERVE_PROXY_TLS_KEY_PATH=/etc/tls/trustbloc.local.key
+      - SERVE_PROXY_TLS_CERT_PATH=/etc/tls/trustbloc.local.crt
+      - VIRTUAL_HOST=oathkeeper-auth-keyserver.trustbloc.local
+      - VIRTUAL_PORT=4459
+      - VIRTUAL_PROTO=https
+    volumes:
+      - ../hubkms-oathkeeper/auth-keyserver:/oathkeeper
+      - ../keys/tls:/etc/tls
+    networks:
+      - demo-net
+
+  oathkeeper-ops-keyserver.trustbloc.local:
+    container_name: oathkeeper-ops-keyserver.trustbloc.local
+    image: oryd/oathkeeper:v0.38.4-alpine
+    ports:
+      - 4460:4460
+    command: /bin/sh -c "cp /etc/tls/trustbloc-dev-ca.crt /usr/local/share/ca-certificates/;update-ca-certificates;oathkeeper serve proxy --config /oathkeeper/config.yaml"
+    user: root
+    entrypoint: ""
+    environment:
+      - LOG_LEVEL=debug
+      - PORT=4460
+      - ISSUER_URL=https://oathkeeper-proxy.trustbloc.local
+      - SERVE_PROXY_TLS_KEY_PATH=/etc/tls/trustbloc.local.key
+      - SERVE_PROXY_TLS_CERT_PATH=/etc/tls/trustbloc.local.crt
+      - VIRTUAL_HOST=oathkeeper-ops-keyserver.trustbloc.local
+      - VIRTUAL_PORT=4460
+      - VIRTUAL_PROTO=https
+    volumes:
+      - ../hubkms-oathkeeper/ops-keyserver:/oathkeeper
+      - ../keys/tls:/etc/tls
+    networks:
+      - demo-net
+
   strapi:
     container_name: strapi
     image: strapi/strapi:3.0.6-alpine
@@ -171,6 +217,8 @@ services:
           - ops-kms.trustbloc.local
           - myagent.trustbloc.local
           - myagent-support.trustbloc.local
+          - oathkeeper-auth-keyserver.trustbloc.local
+          - oathkeeper-ops-keyserver.trustbloc.local
 
   shared.couchdb:
     container_name: shared.couchdb

--- a/test/bdd/fixtures/hubkms-oathkeeper/auth-keyserver/config.yaml
+++ b/test/bdd/fixtures/hubkms-oathkeeper/auth-keyserver/config.yaml
@@ -1,0 +1,37 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+serve:
+  proxy:
+    port: 4459
+  api:
+    port: 4458
+
+access_rules:
+  repositories:
+    - file:///oathkeeper/rules/resource-server.json
+  matching_strategy: glob
+
+authenticators:
+  oauth2_introspection:
+    enabled: true
+    config:
+      introspection_url: https://auth-rest-hydra.trustbloc.local:11202/oauth2/introspect
+  noop:
+    enabled: true
+
+authorizers:
+  allow:
+    enabled: true
+
+mutators:
+  header:
+    enabled: true
+    config:
+      headers:
+        HUB-KMS-USER: '{{ print .Subject }}'
+  noop:
+    enabled: true

--- a/test/bdd/fixtures/hubkms-oathkeeper/auth-keyserver/rules/resource-server.json
+++ b/test/bdd/fixtures/hubkms-oathkeeper/auth-keyserver/rules/resource-server.json
@@ -1,0 +1,68 @@
+[
+  {
+    "id": "auth-kms-create-keystore",
+    "upstream": {
+      "url": "https://authz-kms.trustbloc.local"
+    },
+    "match": {
+      "url": "https://oathkeeper-auth-keyserver.trustbloc.local/kms/keystores",
+      "methods": ["POST"]
+    },
+    "authenticators": [{
+      "handler": "oauth2_introspection"
+    }],
+    "mutators": [
+      {
+        "handler": "noop"
+      }
+    ],
+    "authorizer": {
+      "handler": "allow"
+    }
+  },
+  {
+    "id": "auth-kms-keystore-ops",
+    "upstream": {
+      "url": "https://authz-kms.trustbloc.local"
+    },
+    "match": {
+      "url": "https://oathkeeper-auth-keyserver.trustbloc.local/kms/keystores/<*>",
+      "methods": ["POST", "GET"]
+    },
+    "authenticators": [{
+      "handler": "oauth2_introspection"
+    }],
+    "mutators": [
+      {
+        "handler": "header",
+        "config": {
+          "headers": {
+            "Hub-Kms-User": "{{ print .Subject }}"
+          }
+        }
+      }
+    ],
+    "authorizer": {
+      "handler": "allow"
+    }
+  },
+  {
+    "id": "ops-kms-health",
+    "upstream": {
+      "url": "https://authz-kms.trustbloc.local"
+    },
+    "match": {
+      "url": "http://oathkeeper-auth-keyserver.trustbloc.local/healthcheck",
+      "methods": ["GET"]
+    },
+    "authenticators": [{
+      "handler": "noop"
+    }],
+    "mutators": [{
+      "handler": "noop"
+    }],
+    "authorizer": {
+      "handler": "allow"
+    }
+  }
+]

--- a/test/bdd/fixtures/hubkms-oathkeeper/ops-keyserver/config.yaml
+++ b/test/bdd/fixtures/hubkms-oathkeeper/ops-keyserver/config.yaml
@@ -1,0 +1,37 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+serve:
+  proxy:
+    port: 4460
+  api:
+    port: 4458
+
+access_rules:
+  repositories:
+    - file:///oathkeeper/rules/resource-server.json
+  matching_strategy: glob
+
+authenticators:
+  oauth2_introspection:
+    enabled: true
+    config:
+      introspection_url: https://auth-rest-hydra.trustbloc.local:11202/oauth2/introspect
+  noop:
+    enabled: true
+
+authorizers:
+  allow:
+    enabled: true
+
+mutators:
+  header:
+    enabled: true
+    config:
+      headers:
+        HUB-KMS-USER: '{{ print .Subject }}'
+  noop:
+    enabled: true

--- a/test/bdd/fixtures/hubkms-oathkeeper/ops-keyserver/rules/resource-server.json
+++ b/test/bdd/fixtures/hubkms-oathkeeper/ops-keyserver/rules/resource-server.json
@@ -1,0 +1,66 @@
+[
+  {
+    "id": "ops-kms-create-keystore",
+    "upstream": {
+      "url": "https://ops-kms.trustbloc.local"
+    },
+    "match": {
+      "url": "https://oathkeeper-ops-keyserver.trustbloc.local/kms/keystores",
+      "methods": ["POST"]
+    },
+    "authenticators": [{
+      "handler": "oauth2_introspection"
+    }],
+    "mutators": [{
+      "handler": "noop"
+    }],
+    "authorizer": {
+      "handler": "allow"
+    }
+  },
+  {
+    "id": "ops-kms-keystore-ops",
+    "upstream": {
+      "url": "https://ops-kms.trustbloc.local"
+    },
+    "match": {
+      "url": "https://oathkeeper-ops-keyserver.trustbloc.local/kms/keystores/<*>",
+      "methods": ["POST", "GET"]
+    },
+    "authenticators": [{
+      "handler": "noop"
+    }],
+    "mutators": [
+      {
+        "handler": "header",
+        "config": {
+          "headers": {
+            "Hub-Kms-User": "{{ print .Subject }}"
+          }
+        }
+      }
+    ],
+    "authorizer": {
+      "handler": "allow"
+    }
+  },
+  {
+    "id": "ops-kms-health",
+    "upstream": {
+      "url": "https://ops-kms.trustbloc.local"
+    },
+    "match": {
+      "url": "http://oathkeeper-ops-keyserver.trustbloc.local/healthcheck",
+      "methods": ["GET"]
+    },
+    "authenticators": [{
+      "handler": "noop"
+    }],
+    "mutators": [{
+      "handler": "noop"
+    }],
+    "authorizer": {
+      "handler": "allow"
+    }
+  }
+]


### PR DESCRIPTION
* add oathkeeper instances in front of hub-kms
* edge-agent: refactor bearer token usage for hub-kms/oathkeeper trustbloc/edge-agent#563

Signed-off-by: George Aristy <george.aristy@securekey.com>
