### PR TITLE
chore: enable zcaps authz on ops key server

### DIFF
--- a/scripts/trustbloc_local_setup.sh
+++ b/scripts/trustbloc_local_setup.sh
@@ -44,6 +44,4 @@ cat > ${SANDBOX_HOME}/hosts <<EOF
 127.0.0.1 auth-rest-hydra.trustbloc.local
 127.0.0.1 oathkeeper-auth-keyserver.trustbloc.local
 127.0.0.1 oathkeeper-ops-keyserver.trustbloc.local
-127.0.0.1 ops-kms.trustbloc.local
 EOF
-# TODO remove ops-kms.trustbloc.local after this is fixed: https://github.com/trustbloc/edge-agent/issues/574.

--- a/test/bdd/fixtures/demo/.env
+++ b/test/bdd/fixtures/demo/.env
@@ -13,9 +13,9 @@ CONSENT_LOGIN_SERVER_IMAGE=docker.pkg.github.com/trustbloc/edge-sandbox/login-co
 
 # Edge agent
 USER_AGENT_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/wallet-web
-USER_AGENT_IMAGE_TAG=0.1.5-snapshot-ca90038
+USER_AGENT_IMAGE_TAG=0.1.5-snapshot-6f85fb9
 USER_AGENT_SUPPORT_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/wallet-server
-USER_AGENT_SUPPORT_IMAGE_tag=0.1.5-snapshot-ca90038
+USER_AGENT_SUPPORT_IMAGE_tag=0.1.5-snapshot-6f85fb9
 WALLET_ROUTER_URL=https://router.trustbloc.local:9084
 SUPPORT_BLINDED_ROUTING=true
 
@@ -33,7 +33,7 @@ EDV_IMAGE_TAG=0.1.5-snapshot-f660878
 
 # KMS
 KMS_REST_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/kms-rest
-KMS_REST_TAG=0.1.5-snapshot-da7ba89
+KMS_REST_TAG=0.1.5-snapshot-b185b89
 
 # Sidetree mock
 SIDETREE_MOCK_IMAGE=docker.pkg.github.com/trustbloc-cicd/snapshot/sidetree-mock

--- a/test/bdd/fixtures/demo/docker-compose-edge-components.yml
+++ b/test/bdd/fixtures/demo/docker-compose-edge-components.yml
@@ -269,8 +269,7 @@ services:
     image: ${KMS_REST_IMAGE}:${KMS_REST_TAG}
     environment:
       - KMS_HOST_URL=0.0.0.0:8072
-      # TODO this should be oathkeeper url ref: https://github.com/trustbloc/edge-agent/issues/580
-      - KMS_BASE_URL=https://authz-kms.trustbloc.local
+      - KMS_BASE_URL=https://oathkeeper-auth-keyserver.trustbloc.local
       - KMS_TLS_CACERTS=/etc/tls/trustbloc-dev-ca.crt
       - KMS_TLS_SYSTEMCERTPOOL=true
       - KMS_TLS_SERVE_CERT=/etc/tls/trustbloc.local.crt
@@ -309,8 +308,7 @@ services:
     image: ${KMS_REST_IMAGE}:${KMS_REST_TAG}
     environment:
       - KMS_HOST_URL=0.0.0.0:8073
-      # TODO this should be oathkeeper url ref: https://github.com/trustbloc/edge-agent/issues/580
-      - KMS_BASE_URL=https://ops-kms.trustbloc.local
+      - KMS_BASE_URL=https://oathkeeper-ops-keyserver.trustbloc.local
       - KMS_TLS_CACERTS=/etc/tls/trustbloc-dev-ca.crt
       - KMS_TLS_SYSTEMCERTPOOL=true
       - KMS_TLS_SERVE_CERT=/etc/tls/trustbloc.local.crt
@@ -328,7 +326,7 @@ services:
       - KMS_KEY_MANAGER_STORAGE_URL=https://edv-oathkeeper-proxy.trustbloc.local
       - VIRTUAL_HOST=ops-kms.trustbloc.local
       - VIRTUAL_PROTO=https
-      - KMS_ZCAP_ENABLE=false
+      - KMS_ZCAP_ENABLE=true
     ports:
       - 8073:8073
     entrypoint: ""

--- a/test/bdd/fixtures/hubkms-oathkeeper/auth-keyserver/config.yaml
+++ b/test/bdd/fixtures/hubkms-oathkeeper/auth-keyserver/config.yaml
@@ -7,6 +7,15 @@
 serve:
   proxy:
     port: 4459
+    cors:
+      enabled: true
+      allowed_headers:
+        - Content-Type
+        - Authorization
+        - Hub-Kms-Secret
+      allowed_origins:
+        - https://myagent.trustbloc.local
+      allow_credentials: true
   api:
     port: 4458
 

--- a/test/bdd/fixtures/hubkms-oathkeeper/ops-keyserver/config.yaml
+++ b/test/bdd/fixtures/hubkms-oathkeeper/ops-keyserver/config.yaml
@@ -7,6 +7,18 @@
 serve:
   proxy:
     port: 4460
+    cors:
+      enabled: true
+      allowed_headers:
+        - Content-Type
+        - Authorization
+        - Hub-Kms-Secret
+        - Capability-Invocation
+        - Digest
+        - Signature
+      allowed_origins:
+        - https://myagent.trustbloc.local
+      allow_credentials: true
   api:
     port: 4458
 


### PR DESCRIPTION
Verified with the [New Bank Account Use Case](https://github.com/trustbloc/edge-sandbox/blob/master/docs/demo/new-bank-account-usecase.md#new-bank-account-use-case).

* enable zcaps authz on ops key server
* fix: edge-agent: use correct zcap for ops key operations trustbloc/edge-agent#578
* fix: hub-kms: remove CORS trustbloc/hub-kms#123

Signed-off-by: George Aristy <george.aristy@securekey.com>